### PR TITLE
Add unique ID to divs to support multiple Ploltly graphs per notebook

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
  
 module.exports = (plotlyFn, options = {}) => {
 	const plotlyLocation = 'https://cdn.plot.ly/plotly-latest.min.js';
+	const id = Math.random().toString(36).substr(2, 10);
 	options = Object.assign({
 		width: 550,
 		height: 450,
@@ -16,10 +17,10 @@ module.exports = (plotlyFn, options = {}) => {
 		return `
 			<center>
 				<style>${options.style}</style>
-				<div id="plotly" width=${options.width} height=${options.height}></div>
+				<div id="plotly-${id}" width=${options.width} height=${options.height}></div>
 				<script src="${plotlyLocation}"></script>
 				<script>
-					(${plotlyFn.toString()})(${JSON.stringify(plotlyArgs)}, "plotly", Plotly)
+					(${plotlyFn.toString()})(${JSON.stringify(plotlyArgs)}, "plotly-${id}", Plotly)
 				</script>
 			</center>
 		`;


### PR DESCRIPTION
Currently, attempting to create more than one Plotly graph in a notebook causes the following error:

```
WARN: Calling Plotly.plot as if redrawing but this container doesn't yet have a plot. 
<div id=​"plotly" width=​"550" height=​"450" class=​"js-plotly-plot">​…​</div>​
```

I suspect this is due to the static `plotly` ID being assigned to the divs. Instead, this will generate a random id for each plot.